### PR TITLE
2026-05-12 Production Promotion [ft. Security Fix]

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -47,7 +47,7 @@ COPY system_files /system_files
 # Note: Renovate can automatically update these :latest tags to SHA-256 digests for reproducibility
 COPY --from=ghcr.io/projectbluefin/common:latest@sha256:c1fcbdf3ccf0aaba71f8aaf2b2a5bd0bc507e6d33c8433bdf29584cd705a41cb /system_files /oci/common
 COPY --from=ghcr.io/ublue-os/brew:latest@sha256:20d951fe7826ecc099b924a127eab4949f0a8566b15bf76a22bdb95a49468919 /system_files /oci/brew
-COPY --from=ghcr.io/ublue-os/akmods:main-43 / /oci/akmods
+COPY --from=ghcr.io/ublue-os/akmods:main-43@sha256:2eeecfe2807b7eafc2f30ebf60a12239573051b715b3030d4feabd575e5629df / /oci/akmods
 # Copy from submodule.  We put it under /oci for convenience
 COPY tr-osforge/reusable_scripting /oci/tr-osforge
 

--- a/Containerfile
+++ b/Containerfile
@@ -56,7 +56,7 @@ COPY tr-osforge/reusable_scripting /oci/tr-osforge
 # the ublue main image will produce beta images before the actual release.
 # 
 # The convention for ublue-main is "latest" for current Fedora, and "gts" for Fedora-1
-FROM ghcr.io/ublue-os/silverblue-main:gts@sha256:70845fa8568f9af82628f924407693ed2f901fb4114a9c1bc39f0b3682d01eb5
+FROM ghcr.io/ublue-os/silverblue-main:gts@sha256:df366197baca45f25bcf2077fc3d89a69a50c985b0bbd01f4511265c7ea0a60e
 
 ARG IMAGE_NAME
 ARG TAG

--- a/Containerfile
+++ b/Containerfile
@@ -47,7 +47,7 @@ COPY system_files /system_files
 # Note: Renovate can automatically update these :latest tags to SHA-256 digests for reproducibility
 COPY --from=ghcr.io/projectbluefin/common:latest@sha256:c1fcbdf3ccf0aaba71f8aaf2b2a5bd0bc507e6d33c8433bdf29584cd705a41cb /system_files /oci/common
 COPY --from=ghcr.io/ublue-os/brew:latest@sha256:20d951fe7826ecc099b924a127eab4949f0a8566b15bf76a22bdb95a49468919 /system_files /oci/brew
-COPY --from=ghcr.io/ublue-os/akmods:main-43@sha256:2eeecfe2807b7eafc2f30ebf60a12239573051b715b3030d4feabd575e5629df / /oci/akmods
+COPY --from=ghcr.io/ublue-os/akmods:main-43@sha256:e08b7842f7f015ec23c7b0ac620fae434cdfd4775ea4485f2a40f1c0064f2005 / /oci/akmods
 # Copy from submodule.  We put it under /oci for convenience
 COPY tr-osforge/reusable_scripting /oci/tr-osforge
 

--- a/Containerfile
+++ b/Containerfile
@@ -47,7 +47,7 @@ COPY system_files /system_files
 # Note: Renovate can automatically update these :latest tags to SHA-256 digests for reproducibility
 COPY --from=ghcr.io/projectbluefin/common:latest@sha256:c1fcbdf3ccf0aaba71f8aaf2b2a5bd0bc507e6d33c8433bdf29584cd705a41cb /system_files /oci/common
 COPY --from=ghcr.io/ublue-os/brew:latest@sha256:20d951fe7826ecc099b924a127eab4949f0a8566b15bf76a22bdb95a49468919 /system_files /oci/brew
-COPY --from=ghcr.io/ublue-os/akmods:main-43@sha256:e08b7842f7f015ec23c7b0ac620fae434cdfd4775ea4485f2a40f1c0064f2005 / /oci/akmods
+COPY --from=ghcr.io/ublue-os/akmods:coreos-stable-43@sha256:e2336e26903a58f80ab8f9eb3b285df3bd75dfdb1a29865461bd31a1cb8d8b11 / /oci/akmods
 # Copy from submodule.  We put it under /oci for convenience
 COPY tr-osforge/reusable_scripting /oci/tr-osforge
 

--- a/Containerfile
+++ b/Containerfile
@@ -47,7 +47,7 @@ COPY system_files /system_files
 # Note: Renovate can automatically update these :latest tags to SHA-256 digests for reproducibility
 COPY --from=ghcr.io/projectbluefin/common:latest@sha256:c1fcbdf3ccf0aaba71f8aaf2b2a5bd0bc507e6d33c8433bdf29584cd705a41cb /system_files /oci/common
 COPY --from=ghcr.io/ublue-os/brew:latest@sha256:20d951fe7826ecc099b924a127eab4949f0a8566b15bf76a22bdb95a49468919 /system_files /oci/brew
-COPY --from=ghcr.io/ublue-os/akmods:coreos-stable-43@sha256:26f781b69f39b1df8687b9ab5b3fa93caa5d07aeac92df3d80790a281720e7fb / /oci/akmods
+COPY --from=ghcr.io/ublue-os/akmods:main-43 / /oci/akmods
 # Copy from submodule.  We put it under /oci for convenience
 COPY tr-osforge/reusable_scripting /oci/tr-osforge
 

--- a/Containerfile
+++ b/Containerfile
@@ -56,7 +56,7 @@ COPY tr-osforge/reusable_scripting /oci/tr-osforge
 # the ublue main image will produce beta images before the actual release.
 # 
 # The convention for ublue-main is "latest" for current Fedora, and "gts" for Fedora-1
-FROM ghcr.io/ublue-os/silverblue-main:gts@sha256:82a05c70906212ebb55afe1bbfe25dc5b61cb542a1ae43bd707c45e219e067ef
+FROM ghcr.io/ublue-os/silverblue-main:gts@sha256:70845fa8568f9af82628f924407693ed2f901fb4114a9c1bc39f0b3682d01eb5
 
 ARG IMAGE_NAME
 ARG TAG


### PR DESCRIPTION
Includes patch for CVE-2026-43284

See https://discussion.fedoraproject.org/t/update-to-fix-dirtyfrag-available/190864